### PR TITLE
fix a bug

### DIFF
--- a/stackedae_exercise/stackedAECost.m
+++ b/stackedae_exercise/stackedAECost.m
@@ -88,7 +88,7 @@ softmaxThetaGrad = (-1/m) * (y - p) * a{n+1}' + lambda * softmaxTheta;
 
 % delta
 d = cell(n+1);
-d{n+1} = -(softmaxTheta' * (y - p)) .* a{n+1} .* (1 -a{n});
+d{n+1} = -(softmaxTheta' * (y - p)) .* a{n + 1} .* (1 -a{n + 1});
 
 for l = (n:-1:2)
     d{l} = stack{l}.w' * d{l+1} .* a{l} .* (1-a{l});


### PR DESCRIPTION
I think you mistype <i>a{n + 1} \* (1 - a{n})</i> while it actually should be <i>a{n + 1} \* (1 - a{n + 1})</i>.

In given parameters settings, <b>hiddenSizeL1</b> is coincidentally equal to <b>hiddenSizeL2</b> so your code can run without dimension incompatible problem, however, if you run <b>checkStackedAECost</b>, it won't compile correctly.

Last but not least, really thanks for your code, very helpful to me.
